### PR TITLE
socket: Allow remotes to connect to the host

### DIFF
--- a/debian/eos-kalite-system-helper.socket
+++ b/debian/eos-kalite-system-helper.socket
@@ -3,7 +3,6 @@ Description=KA Lite Server
 
 [Socket]
 ListenStream=8008
-BindToDevice=lo
 
 [Install]
 WantedBy=sockets.target


### PR DESCRIPTION
KA Lite is designed to work with a single server and multiple remote
clients, and we were accidentally blocking this functionality by
only binding the socket to the local host.

https://phabricator.endlessm.com/T13776
